### PR TITLE
Add encoder decoder

### DIFF
--- a/doc/results.md
+++ b/doc/results.md
@@ -47,7 +47,7 @@ If a model was perfectly conditioned, we should expect it to score for the condi
 | <span style='margin-left: 1em'>+ conditional loss (w=1)</span> | 3.4068  | 5 | 3.1848(*2) | 4.7267 | 0.2153 | 0.7637 | 0.8829 | 3.7641 | 0.3011 | 2.4828 | 0.5597 |
 | <span style='margin-left: 1em'>+ conditional loss (w=0.5)</span> | 3.3951 | 5 | 3.1447(*2) | 4.2007 | 0.2861 | 1.0246 | 0.8214 | 3.4086 | 0.3576 | 2.2528 | 0.5890 |
 | Trained with a description of labels verse at the beginning of the poem, missing labels filled by classifiers | 3.3355 | 4 | 3.0313 | 6.3723 | 0.0325 | 2.5009 | 0.5268 | 4.3886 | 0.1980 | 2.8035 | 0.4963 |
-
+| Encoder-decoder distilbert-gpt2, trained with a description of labels fed to encoder, '?' for labels not available | 3.3557 | 2 | 3.1269 | 7.1540 | 0.0108 | 6.5482 | 0.0060 | 4.4718 | 0.1907 | 3.5240 | 0.3789 |
 
 Legend:
 - *1: some poems have only topic as label and others have only form as label, so some examples have a topic in the first position and other examples have the form in the first position of the sequence.

--- a/notebooks/evaluate_conditional_generation.ipynb
+++ b/notebooks/evaluate_conditional_generation.ipynb
@@ -25,13 +25,27 @@
     "2. Delete the labels from the generated text.\n",
     "3. Feed the generated text to the corresponding classifier to evaluate the metrics.\n",
     "\n",
+    "**Procedure A for encoder-decoder** \n",
+    "\n",
+    "If the generator follows an encoder-decoder architecture, the procedure is a bit different because we feed the labels to the encoder:\n",
+    "\n",
+    "1. Generate text using just the labels plus a line break as inputs to the encoder (one label per input sequence, as many sequences as labels) and no prompt for the decoder (start with an empty sequence, only bos token).\n",
+    "2. Feed the generated text to the corresponding classifier to evaluate the metrics.\n",
+    "\n",
     "**Procedure B**\n",
     "\n",
     "1. Generate text using as prompt an initial substring of each sequence in the validation set, with its label and a line break prepended. We are limiting the length of prompt to the minimum between 100 characters and 1/4 of the length of the text.\n",
     "2. Delete the labels from the generated text.\n",
     "3. Feed the generated text to the corresponding classifier to evaluate the metrics.\n",
     "\n",
-    "The dataset/split used in this case is the same dataset that we use as validation set to train the text classifier (see [train_poems_classifier.ipynb](train_poems_classifier.ipynb))\n"
+    "The dataset/split used in this case is the same dataset that we use as validation set to train the text classifier (see [train_poems_classifier.ipynb](train_poems_classifier.ipynb))\n",
+    "\n",
+    "**Procedure B for encoder-decoder** \n",
+    "\n",
+    "If the generator follows an encoder-decoder architecture, the procedure is a bit different because we feed the labels to the encoder and the prompts to the decoder:\n",
+    "\n",
+    "1. Generate text using as prompts (inputs of the decoder) an initial substring of each sequence in the validation set, with its label and a line break as inputs of the encoder. We are limiting the length of prompt to the minimum between 100 characters and 1/4 of the length of the text.\n",
+    "2. Feed the generated text to the corresponding classifier to evaluate the metrics."
    ]
   },
   {
@@ -80,7 +94,7 @@
    "source": [
     "import os\n",
     "import pandas as pd\n",
-    "from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer\n",
+    "from transformers import AutoModelForCausalLM, AutoModelForSequenceClassification, AutoTokenizer, EncoderDecoderModel\n",
     "import torch\n",
     "import torch.nn.functional as F"
    ]
@@ -93,7 +107,7 @@
    "source": [
     "from poemsai.config import set_config_value\n",
     "from poemsai.data import (build_labeled_dfs_from_splits, label_type_to_str, LabelsType, LabelsWriterStd, \n",
-    "                          PoemsFileConfig)\n",
+    "                          LabelsWriterExplained, PoemsFileConfig)\n",
     "from poemsai.metrics import ConditionalGenEvaluator\n",
     "from poemsai.nb_utils import download_checkpoint_from_hf_hub"
    ]
@@ -131,6 +145,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set `gen_model_name` to the checkpoint of the conditional generator you wish to evaluate:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -145,9 +166,31 @@
     "download_checkpoint_from_hf_hub(clf_model_name, HF_USER, hf_pwd)\n",
     "hf_pwd = None\n",
     "gen_model = AutoModelForCausalLM.from_pretrained(gen_model_name)\n",
+    "#gen_model = EncoderDecoderModel.from_pretrained(gen_model_name)\n",
     "clf_model = AutoModelForSequenceClassification.from_pretrained(clf_model_name)\n",
+    "# When `gen_model` is an encoder-decoder, `gen_tokenizer` is the tokenizer of the decoder\n",
     "gen_tokenizer = AutoTokenizer.from_pretrained(gen_model_name)\n",
     "clf_tokenizer = AutoTokenizer.from_pretrained(clf_model_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the text generator `gen_model` is an encoder-decoder and the encoder and decoder have different tokenizers, execute the cell below to load tokenizer of the encoder. Don't forget to set `encoder_checkpoint` to the checkpoint of the pretrained model from which you loaded the encoder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decoder_tokenizer = None\n",
+    "if gen_model.config.is_encoder_decoder:\n",
+    "    decoder_tokenizer = gen_tokenizer\n",
+    "    encoder_checkpoint = \"distilbert-base-uncased\"\n",
+    "    gen_tokenizer = AutoTokenizer.from_pretrained(encoder_checkpoint)"
    ]
   },
   {
@@ -168,7 +211,8 @@
     "file_conf = PoemsFileConfig.from_json('dataset/all.txt/en.txt/only_end_tags/all_poems.en.conf.json')\n",
     "all_cats_ordered = [label_type_to_str(cat) for cat in LabelsType if cat != LabelsType.All]\n",
     "evaluator = ConditionalGenEvaluator(gen_model, gen_tokenizer, clf_model, clf_tokenizer, file_conf,\n",
-    "                                    cat_name, all_cats_ordered, labels_writer=LabelsWriterStd())"
+    "                                    cat_name, all_cats_ordered, labels_writer=LabelsWriterStd(),\n",
+    "                                    gen_decoder_tokenizer=decoder_tokenizer)"
    ]
   },
   {

--- a/notebooks/train_cond_generator.ipynb
+++ b/notebooks/train_cond_generator.ipynb
@@ -76,7 +76,8 @@
     "import tempfile\n",
     "import transformers\n",
     "from transformers import (\n",
-    "    AutoModelForSequenceClassification, AutoTokenizer, default_data_collator, Trainer, TrainingArguments\n",
+    "    AutoModelForSequenceClassification, AutoTokenizer, default_data_collator, EncoderDecoderModel, Trainer, \n",
+    "    TrainingArguments\n",
     ")\n",
     "from transformers.optimization import SchedulerType\n",
     "from transformers.trainer_utils import get_last_checkpoint\n",
@@ -101,10 +102,13 @@
    },
    "outputs": [],
    "source": [
-    "from poemsai.data import LabelsType, LabelsDecoderExplained, Lang, lang_to_str, PoemsFileConfig\n",
+    "from poemsai.data import (\n",
+    "    build_datasets_for_encoder_decoder, label_type_to_str, LabelsType, LabelsDecoderExplained, Lang, lang_to_str, \n",
+    "    PoemsFileConfig, VerseGrouping\n",
+    ")\n",
     "from poemsai.hf_utils import model_to_url\n",
     "from poemsai.metrics import (\n",
-    "    ConditionalGenLoss, get_compute_metrics_metadataless, MetadataLessLoss, \n",
+    "    ConditionalGenLoss, get_compute_metrics_metadataless, MetadataLessLoss, SimpleMetadataLessLoss,\n",
     "    preprocess_logits_for_metadataless_loss\n",
     ")\n",
     "from poemsai.nb_utils import commit_checkpoint_to_hf_hub, download_checkpoint_from_hf_hub\n",
@@ -1972,6 +1976,310 @@
    "source": [
     "commit_checkpoint_to_hf_hub(custom_model_name, HF_USER, get_last_checkpoint('./checkpoints'),\n",
     "                            message='Add model, 4 epochs', pwd='')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tr 10: Encoder-decoder model DistilBert + GPT2, conditions defined as a description of the labels, '?' for labels not available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resume_training = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_model_name = f\"distilbert-gpt2-poems-cond-form-and-topic-exp.{lang_str}\"\n",
+    "model_url = model_to_url(custom_model_name, HF_USER)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clone repo of our model to commit there later\n",
+    "if resume_training:\n",
+    "    hf_pwd = 'YOUR_HUGGING_FACE_PASSWORD'\n",
+    "    download_checkpoint_from_hf_hub(custom_model_name, HF_USER, hf_pwd)\n",
+    "    hf_pwd = ''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "encoder_checkpoint = \"distilbert-base-uncased\"\n",
+    "decoder_checkpoint = \"gpt2\"\n",
+    "encoder_tokenizer = AutoTokenizer.from_pretrained(encoder_checkpoint)\n",
+    "decoder_tokenizer = AutoTokenizer.from_pretrained(decoder_checkpoint)\n",
+    "model = EncoderDecoderModel.from_encoder_decoder_pretrained(encoder_checkpoint, decoder_checkpoint)\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_data_path = Path(f\"dataset/all.txt/{lang_str}.txt/only_end_tags/\")\n",
+    "file_conf_path = base_data_path/\"all_poems.en.conf.json\"\n",
+    "splits_df_path = base_data_path/\"all_poems.en.splits.csv\"\n",
+    "file_config = PoemsFileConfig.from_json(file_conf_path)\n",
+    "# Enforce OnePoemBySequence so that extra linebreaks aren't included between verses\n",
+    "file_config.verse_grouping = VerseGrouping.OnePoemBySequence\n",
+    "splits_df = pd.read_csv(splits_df_path, index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to add the special tokens (beginning of verse and/or end of verse and/or end of poem) only to the tokenizer of the decoder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "begin_verse_id, end_verse_id, end_poem_id = setup_tokenizer(decoder_tokenizer, \n",
+    "                                                            file_config, \n",
+    "                                                            model.decoder)\n",
+    "decoder_tokenizer.all_special_tokens, begin_verse_id, end_verse_id, end_poem_id\n",
+    "if decoder_tokenizer.pad_token_id is None:\n",
+    "    decoder_tokenizer.pad_token = decoder_tokenizer.eos_token\n",
+    "\n",
+    "model.config.decoder_start_token_id = decoder_tokenizer.bos_token_id\n",
+    "model.config.pad_token_id = decoder_tokenizer.pad_token_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def label_func(location:str):\n",
+    "    labels = dict()\n",
+    "    for cat in LabelsType:\n",
+    "        if cat == LabelsType.All: continue\n",
+    "        cat_str = label_type_to_str(cat)\n",
+    "        labels[cat_str] = Path(location).parent.name if f'/{cat.value}/' in location else ''\n",
+    "    return labels\n",
+    "\n",
+    "\n",
+    "def process_data_to_model_inputs(batch):\n",
+    "    # tokenize the inputs (of decoder) and conditions (inputs of encoder)\n",
+    "    inputs = decoder_tokenizer(batch[\"text\"], padding=\"max_length\", truncation=True)\n",
+    "    conditions = encoder_tokenizer(batch[\"labels_text\"], padding=\"max_length\", truncation=True)\n",
+    "    # A potential improvement would be to concatenate inputs with a common condition into the same example\n",
+    "\n",
+    "    batch[\"input_ids\"] = conditions.input_ids\n",
+    "    batch[\"attention_mask\"] = conditions.attention_mask\n",
+    "    # For training, `decoder_input_ids` are automatically created by the model by shifting the `labels` to the\n",
+    "    # right, replacing -100 by the `pad_token_id` and prepending them with the `decoder_start_token_id`.\n",
+    "    #batch[\"decoder_input_ids\"] = inputs.input_ids\n",
+    "    batch[\"decoder_attention_mask\"] = inputs.attention_mask\n",
+    "    batch[\"labels\"] = inputs.input_ids.copy()\n",
+    "\n",
+    "    # because GPT2 automatically shifts the labels, the labels correspond exactly to `decoder_input_ids`. \n",
+    "    # We have to make sure that the PAD token is ignored\n",
+    "    batch[\"labels\"] = [[-100 if token == decoder_tokenizer.pad_token_id else token for token in labels] for labels in batch[\"labels\"]]\n",
+    "\n",
+    "    return batch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the base path of the Kaggle datasets (config key \"KAGGLE_DS_ROOT\") or the base path of our custom dataset (poems of Marcos de la Fuente) differ from those in the cell below, update the configuration keys appropiately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Modify this values if you are running the notebook outside of Kaggle\n",
+    "#set_config_value('KAGGLE_DS_ROOT', '/kaggle/input')\n",
+    "#set_config_value('OWN_DS_ROOT', './dataset')\n",
+    "\n",
+    "train_ds, valid_ds = build_datasets_for_encoder_decoder(splits_df, file_config, label_func)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tokenize and numericalize the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_ds = train_ds.map(\n",
+    "    process_data_to_model_inputs, \n",
+    "    batched=True, \n",
+    "    batch_size=100, \n",
+    "    remove_columns=[\"text\", \"labels_text\"]\n",
+    ")\n",
+    "valid_ds = valid_ds.map(\n",
+    "    process_data_to_model_inputs, \n",
+    "    batched=True, \n",
+    "    batch_size=100, \n",
+    "    remove_columns=[\"text\", \"labels_text\"]\n",
+    ")\n",
+    "\n",
+    "datasets = DatasetDict({'train': train_ds, 'eval': valid_ds})\n",
+    "datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's examine a training example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(encoder_tokenizer.decode(datasets['train'][1000]['input_ids']), \n",
+    " decoder_tokenizer.decode([t if t != -100 else decoder_tokenizer.pad_token_id for t in datasets['train'][1000]['labels']]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look now at a validation example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(encoder_tokenizer.decode(datasets['eval'][0]['input_ids']), \n",
+    "decoder_tokenizer.decode([t if t != -100 else decoder_tokenizer.pad_token_id for t in datasets['eval'][0]['labels']]),)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess_logits_for_encdec_metadataless_loss(logits, labels, ignore_idx=-100):    \n",
+    "    # Before (tr1-tr10): \n",
+    "    # logits (pred after token 0, pred after token 1, pred after token 2, pred after token n-2, pred after token n-1)\n",
+    "    #   =    [ pred token 1,      pred token 2,       pred token 3,       pred token n-1,       pred token n (N/A)]\n",
+    "    # Labels: [token 0,           token 1,            token 2,       ..., token n-2,            token n-1]  \n",
+    "    # shifted logits: [pred token 1, pred token 2, ..., pred token n-1]\n",
+    "    # shifted labels: [token 1,      token 2,      ..., token n-1 ]\n",
+    "    \n",
+    "    # Now (with EncoderDecoderModel):\n",
+    "    # There isn't \"pred token n\" because the token n-1 is deleted from inputs before forward, by shifting right, and\n",
+    "    # model.config.decoder_start_token_id is inserted in the first position of the input ids\n",
+    "    # logits  (pred after bos, pred after token 0, pred after token 1, ..., pred after token n-2)\n",
+    "    #   =     [pred token 0,   pred token 1,       pred token 2,       ..., pred token n-1]\n",
+    "    # labels: [token 0,        token 1,            token 2,            ..., token n-1]\n",
+    "    \n",
+    "    # To have a metric comparable with the previous configurations, we need to remove the first position from both labels and logits.\n",
+    "    # If you don't need to benchmark against the previous examples, just comment out these two lines:\n",
+    "    labels = labels[:, 1:]\n",
+    "    logits = logits[:, 1:]\n",
+    "    \n",
+    "    if (ignore_idx is not None) and (ignore_idx < 0):\n",
+    "        labels = labels.clone()\n",
+    "        # torch.gather will fail if an index is lower than 0\n",
+    "        # The gathered logits for the padded positions are irrelevant, so we can take the first\n",
+    "        labels[labels == ignore_idx] = 0\n",
+    "    return -torch.gather(F.log_softmax(logits, dim=-1), -1, labels[..., None]).squeeze(-1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to set the parameter `pos_0_is_begin_poem = True`, to let the \"Metadata-less loss\" know that it doesn't need to ignore the first tokens of each sequence until it finds the first end of verse token.\n",
+    "Here it's not needed because, unlike in the previous configurations (Tr[1-9]), each example contains exactly one poem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bs = 1\n",
+    "compute_metrics = get_compute_metrics_metadataless(\n",
+    "    begin_verse_id=begin_verse_id, end_verse_id=end_verse_id, end_poem_id=end_poem_id, n_initial_verses_to_ignore=0,\n",
+    "    pos_0_is_begin_poem=True, \n",
+    "    #loss_cls=SimpleMetadataLessLoss\n",
+    ")\n",
+    "trainer = build_trainer(\n",
+    "    model, decoder_tokenizer, datasets, 50, bs=bs, learning_rate=5e-5, compute_metrics=compute_metrics,\n",
+    "    preprocess_logits_for_metrics=preprocess_logits_for_encdec_metadataless_loss,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer.train(\n",
+    "    resume_from_checkpoint=custom_model_name if resume_training else None, \n",
+    "    ignore_keys_for_eval=['past_key_values', 'encoder_last_hidden_state'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls -l checkpoints\n",
+    "custom_model_name, get_last_checkpoint('./checkpoints')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commit_checkpoint_to_hf_hub(custom_model_name, HF_USER, get_last_checkpoint('./checkpoints'),\n",
+    "                            message='Add model, 2 epochs checkpoint', pwd='')"
    ]
   },
   {

--- a/poemsai/data.py
+++ b/poemsai/data.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from datasets import Dataset
 from dataclasses import asdict, dataclass
 from enum import auto, Enum
+import io
 import json
 import numpy as np
 import os
@@ -21,7 +23,7 @@ __all__ = [
     'LabeledPoemsSplitsDfContentReader', 'LabeledPoemsSplitsDfReader', 'LabeledPoemsIOWriter', 
     'BaseLabelsWriter', 'LabelsWriterStd', 'LabelsWriterKeyValue', 'LabelsWriterKeyValueMultiverse', 
     'LabelsWriterExplained', 'LabelsDecoderKeyValue', 'LabelsDecoderExplained', 'build_labeled_dfs_from_splits', 
-    'LabelsEstimator',
+    'build_datasets_for_encoder_decoder', 'LabelsEstimator',
 ]
 
 
@@ -641,6 +643,63 @@ def build_labeled_dfs_from_splits(splits_df:pd.DataFrame, labels_type:LabelsType
     valid_df = valid_df[~valid_empty_selector]
     
     return train_df, valid_df
+
+
+def build_datasets_for_encoder_decoder(
+    splits_df:pd.DataFrame, file_conf:PoemsFileConfig, label_func:Callable[[str], Dict[str, str]]
+) -> Tuple[Dataset, Dataset]:
+    """Construct the datasets needed to train a HuggingFace Encoder-Decoder using the data in `splits_df`.
+
+    Args:
+        splits_df: DataFrame that has one row by poem and assigns each one to an split. It must contain, at least, 
+            the following columns:
+                `POEM_LOCATION_DF_COL`: location specification of a poem, with the same format as the columns of the
+                    same name filled by `PoemsFileList` and `PoemsDf`.
+                'Split': it must have the value 'Train' or 'Validation' depending on whether the poem belongs to the
+                    training set or the validation set.
+            You'd normally use a DataFrame that has been previously stored as a csv by the notebook 
+            'txt_inputs_generator'.
+        file_conf: formatting options that must be applied to the poems before training.
+        label_func: function that receives the location specification of a poem as input and returns a dictionary
+            that contains the labels (values) assigned to each category (keys). The text corresponding to each 
+            categories is given by `label_type_to_str`.
+    Returns:
+        Tuple thats has the training set as the first element and the validation set as the second one.
+        Each of these two datasets has the columns 'text' (text of the poem) and 'labels_text' (labels as encoded
+        by `LabelsWriterExplained`).
+    """
+    splits_df = replace_location_placeholder(splits_df)
+    train_split_df = filter_splits_df(splits_df, LabelsType.All, 'Train')
+    valid_split_df = filter_splits_df(splits_df, LabelsType.All, 'Validation')
+    
+    readers = [LabeledPoemsSplitsDfReader(df, label_func) for df in (train_split_df, valid_split_df)]
+    encoded_dfs = []
+    labels_writer = LabelsWriterExplained()
+    
+    encoded_dfs = []
+    for reader in readers:
+        encoded_df_columns = {'text': [], 'labels_text': []}
+        for poem in reader:
+            with io.StringIO() as labels_io:
+                # This writes endofverse token, which shouldn't be needed for the encoder
+                labels_io_writer = PoemsIOWriter(labels_io, file_conf)  
+                labels_writer.write_labels(poem.labels, labels_io_writer)
+                labels_text = labels_io.getvalue()
+            with io.StringIO() as content_io:
+                content_io_writer = PoemsIOWriter(content_io, file_conf)
+                content_io_writer.write_poem(poem.poem_lines)
+                poem_text = content_io.getvalue()
+
+            encoded_df_columns['text'].append(poem_text)
+            encoded_df_columns['labels_text'].append(labels_text)
+
+        encoded_dfs.append(pd.DataFrame(encoded_df_columns))
+        
+    encoded_train_df, encoded_valid_df = encoded_dfs
+    train_ds = Dataset.from_pandas(encoded_train_df)
+    valid_ds = Dataset.from_pandas(encoded_valid_df)
+    
+    return train_ds, valid_ds
 
 
 class LabelsEstimator:

--- a/poemsai/pipelines.py
+++ b/poemsai/pipelines.py
@@ -1,0 +1,53 @@
+from transformers import Text2TextGenerationPipeline
+from transformers.tokenization_utils_base import TruncationStrategy
+
+
+class EncoderDecoderText2TextGenerationPipeline(Text2TextGenerationPipeline):
+    """Text2Text pipeline for encoder-decoders that accepts a different tokenizer for the decoder and initial prompts.
+    
+    When `model` is an encoder-decoder, each input of the pipeline must be a dictionary with keys 'condition' (input)
+    of the encoder and 'prompt' (input of the decoder).
+    """
+    def __init__(self, *args, decoder_tokenizer=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.decoder_tokenizer = decoder_tokenizer
+
+    def _parse_and_tokenize(self, *args, truncation, tokenizer):
+        prefix = self.model.config.prefix if self.model.config.prefix is not None else ""
+        if isinstance(args[0], list):
+            if tokenizer.pad_token_id is None:
+                raise ValueError("Please make sure that the tokenizer has a pad_token_id when using a batch input")
+            args = ([prefix + arg for arg in args[0]],)
+            padding = True
+
+        elif isinstance(args[0], str):
+            args = (prefix + args[0],)
+            padding = False
+        else:
+            raise ValueError(
+                f" `args[0]`: {args[0]} have the wrong format. The should be either of type `str` or type `list`"
+            )
+        inputs = tokenizer(*args, padding=padding, truncation=truncation, return_tensors=self.framework)
+        # This is produced by tokenizers but is an invalid generate kwargs
+        if "token_type_ids" in inputs:
+            del inputs["token_type_ids"]
+        return inputs
+
+    def preprocess(self, inputs, truncation=TruncationStrategy.DO_NOT_TRUNCATE, **kwargs):
+        if not self.model.config.is_encoder_decoder:
+            inputs = self._parse_and_tokenize(inputs, truncation=truncation, tokenizer=self.tokenizer, **kwargs)
+            return inputs
+        else:
+            assert isinstance(inputs, dict), (
+                'Only a dictionary is accepted as inputs'
+            )
+            decoder_inputs = self._parse_and_tokenize(
+                inputs['prompt'], truncation=truncation, tokenizer=self.decoder_tokenizer, **kwargs
+            )
+            inputs = self._parse_and_tokenize(
+                inputs['condition'], truncation=truncation, tokenizer=self.tokenizer, **kwargs
+            )
+            inputs['decoder_input_ids'] = decoder_inputs['input_ids']
+            inputs['decoder_attention_mask'] = decoder_inputs['attention_mask']
+            return inputs

--- a/poemsai/pipelines.py
+++ b/poemsai/pipelines.py
@@ -48,6 +48,7 @@ class EncoderDecoderText2TextGenerationPipeline(Text2TextGenerationPipeline):
             inputs = self._parse_and_tokenize(
                 inputs['condition'], truncation=truncation, tokenizer=self.tokenizer, **kwargs
             )
-            inputs['decoder_input_ids'] = decoder_inputs['input_ids']
-            inputs['decoder_attention_mask'] = decoder_inputs['attention_mask']
+            if decoder_inputs['input_ids'].shape[-1] > 0:
+                inputs['decoder_input_ids'] = decoder_inputs['input_ids']
+                inputs['decoder_attention_mask'] = decoder_inputs['attention_mask']
             return inputs


### PR DESCRIPTION
This PR adds the tools needed to train and evaluate a conditional generator with encoder-decoder architecture.
@ismaelfaro 

Moreover, it has been tested with a DistilBert (encoder) + GPT2 (decoder). The results in terms of overall quality are similar to what we had, while the conditional metrics are clearly worse (see docs/results.md). One possible reason I see is that it's probably easier for a decoder-only to learn to use the labels contained in the text it receives, encoded in its own language (embeddings)... than it is for a encoder to translate its features to what a different model, the decoder, needs (cross-attention) to condition its output.

Some ideas to explore in the future: 
- In addition to feed the labels to encoder, prepend the labels to the inputs of the decoder too, like we have done with the rest of the conditional generators.
- Try other combinations of architectures. [In this post](https://huggingface.co/blog/warm-starting-encoder-decoder), they show some examples were better results were obtained combining the same model; however, I think the problem types evaluated are quite different to ours despite being sequence to sequence too. For instance, summarization has little to do with our problem.
- Train/finetune a model that's originally a full encoder-decoder like T5 or any other.

